### PR TITLE
Adding support for --fstype TYPE

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Usage: macinbox [options]
 
     -n, --name NAME                  Name of the box         (default: macinbox)
     -d, --disk SIZE                  Size (GB) of the disk   (default: 64)
+    -t, --fstype TYPE                Type for disk format    (default: HFS+J)
     -m, --memory SIZE                Size (MB) of the memory (default: 2048)
     -c, --cpu COUNT                  Number of virtual cores (default: 2)
     -s, --short NAME                 Short name of the user  (default: vagrant)

--- a/lib/macinbox/cli/options.rb
+++ b/lib/macinbox/cli/options.rb
@@ -10,6 +10,7 @@ module Macinbox
       :box_format      => "vmware_fusion",
       :box_name        => "macinbox",
       :disk_size       => 64,
+      :fstype          => "HFS+J",
       :memory_size     => 2048,
       :cpu_count       => 2,
       :short_name      => "vagrant",
@@ -36,6 +37,7 @@ module Macinbox
         o.separator ''
         o.on('-n', '--name NAME',          'Name of the box         (default: macinbox)') { |v| @options[:box_name] = v }
         o.on('-d', '--disk SIZE',          'Size (GB) of the disk   (default: 64)')       { |v| @options[:disk_size] = v }
+        o.on('-t', '--fstype TYPE',        'Type of FS on the disk  (default: HFS+J)')    { |v| @options[:fstype] = v }
         o.on('-m', '--memory SIZE',        'Size (MB) of the memory (default: 2048)')     { |v| @options[:memory_size] = v }
         o.on('-c', '--cpu COUNT',          'Number of virtual cores (default: 2)')        { |v| @options[:cpu_count] = v }
         o.on('-s', '--short NAME',         'Short name of the user  (default: vagrant)')  { |v| @options[:short_name] = v }


### PR DESCRIPTION
Allows to specify the target disk filesystem setup.
This allows for a APFS formatted disk in addition to HFS+J.
See man page for hdiutil under verb create for possible filesystems
supported by the command. APFS and HFS+J have been tested.