### PR TITLE
Fix progress bar crashing when macinbox is not run in a TTY

### DIFF
--- a/lib/macinbox/task.rb
+++ b/lib/macinbox/task.rb
@@ -19,6 +19,8 @@ module Macinbox
     end
 
     def self.progress_bar(activity, percent_done)
+      return '' unless STDOUT.tty?
+
       @spinner ||= Enumerator.new { |e| loop { e.yield '|'; e.yield '/'; e.yield '-'; e.yield '\\' } }
       columns = STDOUT.winsize[1] - 8
       header = activity + ": " + percent_done.round(0).to_s + "% done "


### PR DESCRIPTION
The `progress_bar` function is accessing `STDOUT.winsize` which assumes that the program is run in a tty, which crashes with a `ENOTTY` error code without this change. 

Right now I'm monkey patching `Macinbox` to make it work:

```
module MacinboxPatch
  def progress_bar(*args)
    return '' unless STDOUT.tty?

    super(*args)
  end
end

class Macinbox::Task
  class << self
    prepend MacinboxPatch
  end
end
```

With this change in place Macinbox simply does not print the `progress_bar`, which is the desired behaviour for my use-case.  