### PR TITLE
Favor `reverse_each` over `reverse.each`

### DIFF
--- a/lib/macinbox/collector.rb
+++ b/lib/macinbox/collector.rb
@@ -17,7 +17,7 @@ module Macinbox
         Logger.error "WARNING: Temporary files were not removed. Run this command to remove them:"
         Logger.error "sudo rm -rf #{temp_dir_args}"
       else
-        @temp_dirs.reverse.each do |temp_dir|
+        @temp_dirs.reverse_each do |temp_dir|
           FileUtils.remove_dir(temp_dir)
         end
       end


### PR DESCRIPTION
As per [`fast-ruby` documentation](https://github.com/JuanitoFatas/fast-ruby#enumerablereverseeach-vs-enumerablereverse_each-code), a small speed improvement could be had by favoring `reverse_each` over `reverse.each`