### PR TITLE
Adds kext whitelisting for VMware Tools from Fusion 11.5.3 (#45)

### DIFF
--- a/lib/macinbox/actions/create_vmdk_from_image.rb
+++ b/lib/macinbox/actions/create_vmdk_from_image.rb
@@ -36,10 +36,8 @@ module Macinbox
         create_temp_dir
         copy_input_image
         attach_image
-        if @macos_version.is_mojave_or_earlier?
-          install_vmware_tools
-          set_spc_kextpolicy
-        end
+        set_spc_kextpolicy
+        install_vmware_tools
         eject_image
         convert_image
         save_image
@@ -123,6 +121,8 @@ module Macinbox
             pipe.write <<~EOF
               PRAGMA foreign_keys=OFF;
               BEGIN TRANSACTION;
+              INSERT OR REPLACE INTO kext_load_history_v3 VALUES('/Library/Extensions/VMwareGfx.kext','EG7KH642X6','com.vmware.kext.VMwareGfx','F5E8FB21-EE9B-47F0-9C9C-FD6C4E41AC99','2020-04-13 16:29:03','2020-04-13 16:30:58',55);
+              INSERT OR REPLACE INTO kext_load_history_v3 VALUES('/Library/Application Support/VMware Tools/vmhgfs.kext','EG7KH642X6','com.vmware.kext.vmhgfs','F5E8FB21-EE9B-47F0-9C9C-FD6C4E41AC99','2020-04-13 16:29:04','2020-04-13 16:29:45',53);
               INSERT OR REPLACE INTO kext_policy VALUES('EG7KH642X6','com.vmware.kext.VMwareGfx',1,'VMware, Inc.',1);
               INSERT OR REPLACE INTO kext_policy VALUES('EG7KH642X6','com.vmware.kext.vmmemctl',1,'VMware, Inc.',1);
               INSERT OR REPLACE INTO kext_policy VALUES('EG7KH642X6','com.vmware.kext.vmhgfs',1,'VMware, Inc.',1);


### PR DESCRIPTION
This adds the kernel extension approval to the KextPolicy that is necessary for VMware Tools to load, a new requirement for Catalina. The new configuration may (or may not) be specific to the VMware Tools bundled with Fusion 11.5.3 (currently the latest), which was the version that was installed and approved in order to observe these values.

NB: At some point while researching this issue I found ["the origin of macinbox"](https://gist.github.com/bacongravy/9b3b38d4c3bd9a4f13ba287df4106034#file-prepare_vmdk-sh-L144-L145) and found that it too also had these declarations in the KextPolicy. Observe that the values for `boot_uuid` and `flags` are different than in this diff.

#### For consideration
My goal for this change was to have something that worked, and there's a few things that I didn't take into consideration originally that perhaps should be. Feel free to iterate on the PR, which I'm mostly intending as a vehicle to share this configuration and the learnings I found.

1. I swapped the order of the VMware Tools installation and setting the KextPolicy, just in case the installation of the Tools would not successfully complete unless the KextPolicy already permitted it. I did not test whether or not the ordering matters.
2. This change includes the `created_at` and `last_seen` values for my manual installation of the Tools. While I would be surprised if these values had any unintended consequences for various use cases, in that case it might be good to get them from the system clock (or the clock of the VM, if that's known by this point).
3. The KextPolicy SQLite3 database seems to undergo at least one migration on first boot, which adds another column `cd_hash` (a code signature fingerprint, which is computed at migration time) to the `kext_load_history_v3` table, along with some other metadata about the migration(s). I wasn't able to figure out the macOS version compatibility story for the migration(s), so I avoided incorporating those changes here. I also figure that since the `cd_hash` should be different for each version of the kexts, not including it here should add some future-proofness (although I cannot speak to the other values).
4. I explicitly didn't change the note about VMware Tools/Catalina support in the README.md, since I'm not entirely sure how to advertise version support. I wasn't super comfortable communicating anything other than explicit support for this Fusion version.

#### Testing
Created a Fusion VM using this change, and was able to successfully get the IP address of the VM (`vmrun -T fusion getGuestIPAddress`) which does not work unless the VMware Tools are installed).